### PR TITLE
BSP-804: Update the method of installing Craft updates on the website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM php:7.3-apache
 
 LABEL maintainer = "Mark Hobson <mark.hobson@blackpepper.co.uk>"
 
+# Set craft installer and CMS versions
+ARG CMS_VERSION=3.6.5.1
+ARG CRAFT_VERSION=1.1.2
+
 WORKDIR /var/www
 
 RUN apt-get update \
@@ -14,16 +18,13 @@ RUN apt-get update \
 # Enable .htaccess
 RUN a2enmod rewrite
 
-# Retrieve and unzip craft
-ARG CRAFT_VERSION=3.6
-ARG CRAFT_BUILD=3
-ENV CRAFT_ZIP=Craft-$CRAFT_VERSION.$CRAFT_BUILD.zip
-RUN wget https://download.craftcdn.com/craft/$CRAFT_VERSION/$CRAFT_ZIP -O /tmp/$CRAFT_ZIP \
-    && unzip -q /tmp/$CRAFT_ZIP -d /var/www/ \
-	&& rm /tmp/$CRAFT_ZIP \
+# Download and configure Craft
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+	&& rm -r /var/www/* \
+	&& composer create-project craftcms/craft /var/www $CRAFT_VERSION \
+	&& composer require -W -d /var/www craftcms/cms:$CMS_VERSION \
 	&& chmod +x /var/www/craft \
 	&& sed -i "s/html/web/" /etc/apache2/sites-available/000-default.conf \
-	&& rm -r /var/www/html \
 	&& chown -R www-data:www-data /var/www/* /var/www/.[^.]* \
 	&& echo "php_value memory_limit 256M" >> /var/www/web/.htaccess \
 	&& service apache2 restart
@@ -31,7 +32,6 @@ RUN wget https://download.craftcdn.com/craft/$CRAFT_VERSION/$CRAFT_ZIP -O /tmp/$
 # Move our general config file into config directory
 ADD --chown=www-data:www-data general.php /var/www/config/
 
-# Set up security key
 USER www-data
 
 # Set environment variables
@@ -44,6 +44,7 @@ ENV DB_DRIVER=mysql \
 	DB_TABLE_PREFIX=craft \
 	DB_DATABASE=""
 
+# Set up security key
 RUN /var/www/craft setup/security-key
 
 USER root


### PR DESCRIPTION
Use Composer to install and configure Craft CMS instead of the deprecated manual installation method